### PR TITLE
refactor: replace EF annotations with SqlSugar

### DIFF
--- a/src/Smartstore.Core/Catalog/Attributes/Domain/ProductAttributeOption.cs
+++ b/src/Smartstore.Core/Catalog/Attributes/Domain/ProductAttributeOption.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -90,7 +91,7 @@ namespace Smartstore.Core.Catalog.Attributes
         /// <summary>
         /// Gets or sets the product attribute value type.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public ProductVariantAttributeValueType ValueType
         {
             get => (ProductVariantAttributeValueType)ValueTypeId;

--- a/src/Smartstore.Core/Catalog/Attributes/Domain/ProductVariantAttribute.cs
+++ b/src/Smartstore.Core/Catalog/Attributes/Domain/ProductVariantAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -90,7 +91,7 @@ namespace Smartstore.Core.Catalog.Attributes
         /// <summary>
         /// Gets or sets the attribute control type.
         /// </summary>
-		[NotMapped]
+		[SugarColumn(IsIgnore = true)]
         public AttributeControlType AttributeControlType
         {
             get => (AttributeControlType)AttributeControlTypeId;
@@ -105,7 +106,7 @@ namespace Smartstore.Core.Catalog.Attributes
         /// <summary>
         /// Gets or sets a value indicating whether the selection of multiple values is supported.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public bool IsMultipleChoice => AttributeControlType == AttributeControlType.Checkboxes;
 
         /// <summary>

--- a/src/Smartstore.Core/Catalog/Attributes/Domain/ProductVariantAttributeValue.cs
+++ b/src/Smartstore.Core/Catalog/Attributes/Domain/ProductVariantAttributeValue.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -94,7 +95,7 @@ namespace Smartstore.Core.Catalog.Attributes
         /// <summary>
         /// Gets or sets the product attribute value type.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public ProductVariantAttributeValueType ValueType
         {
             get => (ProductVariantAttributeValueType)ValueTypeId;

--- a/src/Smartstore.Core/Catalog/Discounts/Domain/Discount.cs
+++ b/src/Smartstore.Core/Catalog/Discounts/Domain/Discount.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
 using System.Runtime.Serialization;
@@ -134,7 +135,7 @@ namespace Smartstore.Core.Catalog.Discounts
         /// <summary>
         /// Gets or sets the discount type.
         /// </summary>
-		[NotMapped]
+		[SugarColumn(IsIgnore = true)]
         public DiscountType DiscountType
         {
             get => (DiscountType)DiscountTypeId;
@@ -185,7 +186,7 @@ namespace Smartstore.Core.Catalog.Discounts
         /// <summary>
         /// Gets or sets the discount limitation.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public DiscountLimitationType DiscountLimitation
         {
             get => (DiscountLimitationType)DiscountLimitationId;

--- a/src/Smartstore.Core/Catalog/Products/Domain/Product.cs
+++ b/src/Smartstore.Core/Catalog/Products/Domain/Product.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Frozen;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
@@ -143,7 +144,7 @@ namespace Smartstore.Core.Catalog.Products
         /// <summary>
         /// Gets or sets the product type.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public ProductType ProductType
         {
             get => (ProductType)ProductTypeId;
@@ -153,7 +154,7 @@ namespace Smartstore.Core.Catalog.Products
         /// <summary>
         /// Gets the label hint for the product type.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public string ProductTypeLabelHint
         {
             get
@@ -337,7 +338,7 @@ namespace Smartstore.Core.Catalog.Products
         /// <summary>
         /// Gets or sets the gift card type.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public GiftCardType GiftCardType
         {
             get => (GiftCardType)GiftCardTypeId;
@@ -394,7 +395,7 @@ namespace Smartstore.Core.Catalog.Products
         /// <summary>
         /// Gets or sets the download activation type.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public DownloadActivationType DownloadActivationType
         {
             get => (DownloadActivationType)DownloadActivationTypeId;
@@ -450,7 +451,7 @@ namespace Smartstore.Core.Catalog.Products
         /// <summary>
         /// Gets or sets the cycle period for recurring products.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public RecurringProductCyclePeriod RecurringCyclePeriod
         {
             get => (RecurringProductCyclePeriod)RecurringCyclePeriodId;
@@ -502,7 +503,7 @@ namespace Smartstore.Core.Catalog.Products
         /// <summary>
         /// Gets or sets a value indicating how to manage the inventory.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public ManageInventoryMethod ManageInventoryMethod
         {
             get => (ManageInventoryMethod)ManageInventoryMethodId;
@@ -543,7 +544,7 @@ namespace Smartstore.Core.Catalog.Products
         /// <summary>
         /// Gets or sets the low stock activity.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public LowStockActivity LowStockActivity
         {
             get => (LowStockActivity)LowStockActivityId;
@@ -569,7 +570,7 @@ namespace Smartstore.Core.Catalog.Products
         /// <summary>
         /// Gets or sets the backorder mode.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public BackorderMode BackorderMode
         {
             get => (BackorderMode)BackorderModeId;
@@ -913,7 +914,7 @@ namespace Smartstore.Core.Catalog.Products
         /// <summary>
         /// Gets or sets a value indicating whether the product has a base price.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public bool BasePriceHasValue => BasePriceEnabled && BasePriceAmount.GetValueOrDefault() > 0 && BasePriceBaseAmount.GetValueOrDefault() > 0 && BasePriceMeasureUnit.HasValue();
 
         /// <summary>

--- a/src/Smartstore.Core/Checkout/Attributes/Domain/CheckoutAttribute.cs
+++ b/src/Smartstore.Core/Checkout/Attributes/Domain/CheckoutAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Smartstore.Core.Catalog.Attributes;
@@ -71,7 +72,7 @@ namespace Smartstore.Core.Checkout.Attributes
         /// <summary>
         /// Gets the attribute control type
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public AttributeControlType AttributeControlType
         {
             get => (AttributeControlType)AttributeControlTypeId;

--- a/src/Smartstore.Core/Checkout/Cart/Domain/ShoppingCartItem.cs
+++ b/src/Smartstore.Core/Checkout/Cart/Domain/ShoppingCartItem.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -87,7 +88,7 @@ namespace Smartstore.Core.Checkout.Cart
         /// <summary>
         /// Gets or sets the shopping cart type
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public ShoppingCartType ShoppingCartType
         {
             get => (ShoppingCartType)ShoppingCartTypeId;
@@ -137,21 +138,21 @@ namespace Smartstore.Core.Checkout.Cart
         /// <summary>
         /// Gets a value indicating whether the shopping cart item is free shipping
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public bool IsFreeShipping
             => Product?.IsFreeShipping == true;
 
         /// <summary>
         /// Gets a value indicating whether the shopping cart item is ship enabled
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public bool IsShippingEnabled
             => Product?.IsShippingEnabled ?? true;
 
         /// <summary>
         /// Gets a value indicating whether the shopping cart item is tax exempt
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public bool IsTaxExempt
             => Product?.IsTaxExempt == true;
 

--- a/src/Smartstore.Core/Checkout/GiftCards/Domain/GiftCard.cs
+++ b/src/Smartstore.Core/Checkout/GiftCards/Domain/GiftCard.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -30,7 +31,7 @@ namespace Smartstore.Core.Checkout.GiftCards
         /// <summary>
         /// Gets or sets the gift card type
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public GiftCardType GiftCardType
         {
             get => (GiftCardType)GiftCardTypeId;

--- a/src/Smartstore.Core/Checkout/Orders/Domain/Order.cs
+++ b/src/Smartstore.Core/Checkout/Orders/Domain/Order.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
 using System.Globalization;
@@ -426,7 +427,7 @@ namespace Smartstore.Core.Checkout.Orders
         /// <summary>
         /// Gets or sets the order status
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public OrderStatus OrderStatus
         {
             get => (OrderStatus)OrderStatusId;
@@ -441,7 +442,7 @@ namespace Smartstore.Core.Checkout.Orders
         /// <summary>
         /// Gets or sets the payment status
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public PaymentStatus PaymentStatus
         {
             get => (PaymentStatus)PaymentStatusId;
@@ -456,7 +457,7 @@ namespace Smartstore.Core.Checkout.Orders
         /// <summary>
         /// Gets or sets the shipping status
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public ShippingStatus ShippingStatus
         {
             get => (ShippingStatus)ShippingStatusId;
@@ -471,7 +472,7 @@ namespace Smartstore.Core.Checkout.Orders
         /// <summary>
         /// Gets or sets the customer tax display type
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public TaxDisplayType CustomerTaxDisplayType
         {
             get => (TaxDisplayType)CustomerTaxDisplayTypeId;
@@ -582,7 +583,7 @@ namespace Smartstore.Core.Checkout.Orders
         /// <summary>
         /// Gets the applied tax rates
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public SortedDictionary<decimal, decimal> TaxRatesDictionary => ParseTaxRates(TaxRates);
 
         protected static SortedDictionary<decimal, decimal> ParseTaxRates(string taxRatesStr)

--- a/src/Smartstore.Core/Checkout/Orders/Domain/ReturnRequest.cs
+++ b/src/Smartstore.Core/Checkout/Orders/Domain/ReturnRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Smartstore.Core.Identity;
@@ -81,7 +82,7 @@ namespace Smartstore.Core.Checkout.Orders
         /// <summary>
         /// Gets or sets the return status.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public ReturnRequestStatus ReturnRequestStatus
         {
             get => (ReturnRequestStatus)ReturnRequestStatusId;

--- a/src/Smartstore.Core/Checkout/Payment/Domain/RecurringPayment.cs
+++ b/src/Smartstore.Core/Checkout/Payment/Domain/RecurringPayment.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
+using SqlSugar;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Smartstore.Core.Catalog.Products;
@@ -38,7 +39,7 @@ namespace Smartstore.Core.Checkout.Payment
         /// <summary>
         /// Gets or sets the payment status.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public RecurringProductCyclePeriod CyclePeriod
         {
             get => (RecurringProductCyclePeriod)CyclePeriodId;

--- a/src/Smartstore.Core/Content/Media/Domain/MediaTrack.cs
+++ b/src/Smartstore.Core/Content/Media/Domain/MediaTrack.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -95,7 +96,7 @@ namespace Smartstore.Core.Content.Media
         /// <summary>
         /// Gets or sets the media track operation.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public MediaTrackOperation Operation { get; set; }
 
         protected override bool Equals(BaseEntity other)

--- a/src/Smartstore.Core/Platform/DataExchange/Domain/ExportDeployment.cs
+++ b/src/Smartstore.Core/Platform/DataExchange/Domain/ExportDeployment.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -61,7 +62,7 @@ namespace Smartstore.Core.DataExchange
         /// <summary>
         /// The deployment type.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public ExportDeploymentType DeploymentType
         {
             get => (ExportDeploymentType)DeploymentTypeId;

--- a/src/Smartstore.Core/Platform/DataExchange/Domain/ImportProfile.cs
+++ b/src/Smartstore.Core/Platform/DataExchange/Domain/ImportProfile.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -43,7 +44,7 @@ namespace Smartstore.Core.DataExchange
         /// <summary>
         /// The file type.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public ImportFileType FileType
         {
             get => (ImportFileType)FileTypeId;
@@ -58,7 +59,7 @@ namespace Smartstore.Core.DataExchange
         /// <summary>
         /// The entity type.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public ImportEntityType EntityType
         {
             get => (ImportEntityType)EntityTypeId;

--- a/src/Smartstore.Core/Platform/Identity/Domain/Customer.cs
+++ b/src/Smartstore.Core/Platform/Identity/Domain/Customer.cs
@@ -7,6 +7,7 @@ using Smartstore.Core.Checkout.Cart;
 using Smartstore.Core.Checkout.Orders;
 using Smartstore.Core.Common;
 using Smartstore.Core.Stores;
+using SqlSugar;
 
 namespace Smartstore.Core.Identity
 {
@@ -107,7 +108,7 @@ namespace Smartstore.Core.Identity
         /// <summary>
         /// Gets or sets the password format
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         [IgnoreDataMember]
         public PasswordFormat PasswordFormat
         {
@@ -125,7 +126,7 @@ namespace Smartstore.Core.Identity
         /// Gets or sets a value indicating whether the customer was detected
         /// cookie-less by evaluating the ClientIdent (IP+UserAgent).
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         [IgnoreDataMember]
         public bool DetectedByClientIdent { get; set; }
 

--- a/src/Smartstore.Core/Platform/Logging/Domain/Log.cs
+++ b/src/Smartstore.Core/Platform/Logging/Domain/Log.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -114,7 +115,7 @@ namespace Smartstore.Core.Logging
         /// <summary>
         /// Gets or sets the log level
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public LogLevel LogLevel
         {
             get => (LogLevel)LogLevelId;

--- a/src/Smartstore.Core/Platform/Messaging/Domain/EmailAccount.cs
+++ b/src/Smartstore.Core/Platform/Messaging/Domain/EmailAccount.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
 using Smartstore.Data.Caching;
@@ -58,7 +59,7 @@ namespace Smartstore.Core.Messaging
         /// <summary>
         /// Gets or sets an option for SSL and/or TLS encryption to use.
         /// </summary>
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public MailSecureOption MailSecureOption
         {
             get => (MailSecureOption)SecureOption;

--- a/src/Smartstore.Core/Platform/Messaging/Domain/QueuedEmailAttachment.cs
+++ b/src/Smartstore.Core/Platform/Messaging/Domain/QueuedEmailAttachment.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -115,7 +116,7 @@ namespace Smartstore.Core.Messaging
             set => _mediaStorage = value;
         }
 
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         int IMediaAware.Size { get; set; }
     }
 }

--- a/src/Smartstore.Core/Platform/Rules/Domain/RuleEntity.cs
+++ b/src/Smartstore.Core/Platform/Rules/Domain/RuleEntity.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using SqlSugar;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.Serialization;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Smartstore.Core.Rules
 {
@@ -14,11 +14,11 @@ namespace Smartstore.Core.Rules
         public int RuleSetId { get; set; }
 
         private RuleSetEntity _ruleSet;
-        [ForeignKey("RuleSetId")]
+        [Navigate(NavigateType.ManyToOne, nameof(RuleSetId))]
         [IgnoreDataMember]
         public RuleSetEntity RuleSet
         {
-            get => _ruleSet = LazyLoader.Load(this, ref _ruleSet);
+            get => _ruleSet;
             set => _ruleSet = value;
         }
 
@@ -33,7 +33,7 @@ namespace Smartstore.Core.Rules
 
         public int DisplayOrder { get; set; }
 
-        [NotMapped]
+        [SugarColumn(IsIgnore = true)]
         public bool IsGroup => RuleType.EqualsNoCase("Group");
 
         public RuleEntity Clone()

--- a/src/Smartstore.Core/Platform/Security/Domain/PermissionRoleMapping.cs
+++ b/src/Smartstore.Core/Platform/Security/Domain/PermissionRoleMapping.cs
@@ -1,6 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Smartstore.Core.Identity;
+﻿using Smartstore.Core.Identity;
+using SqlSugar;
 
 namespace Smartstore.Core.Security
 {
@@ -23,10 +22,10 @@ namespace Smartstore.Core.Security
         /// <summary>
         /// Gets or sets the permission record.
         /// </summary>
-        [ForeignKey("PermissionRecordId")]
+        [Navigate(NavigateType.ManyToOne, nameof(PermissionRecordId))]
         public PermissionRecord PermissionRecord
         {
-            get => _permissionRecord ?? LazyLoader.Load(this, ref _permissionRecord);
+            get => _permissionRecord;
             set => _permissionRecord = value;
         }
 
@@ -39,10 +38,10 @@ namespace Smartstore.Core.Security
         /// <summary>
         /// Gets or sets the customer role.
         /// </summary>
-        [ForeignKey("CustomerRoleId")]
+        [Navigate(NavigateType.ManyToOne, nameof(CustomerRoleId))]
         public CustomerRole CustomerRole
         {
-            get => _customerRole ?? LazyLoader.Load(this, ref _customerRole);
+            get => _customerRole;
             set => _customerRole = value;
         }
     }

--- a/src/Smartstore.Core/Platform/Seo/Domain/NamedEntity.cs
+++ b/src/Smartstore.Core/Platform/Seo/Domain/NamedEntity.cs
@@ -1,8 +1,9 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
+using SqlSugar;
 
 namespace Smartstore.Core.Seo
 {
-    [NotMapped]
+    [SugarColumn(IsIgnore = true)]
     public sealed class NamedEntity : BaseEntity, ISlugSupported
     {
         public string EntityName { get; set; }

--- a/src/Smartstore/Domain/BaseEntity.cs
+++ b/src/Smartstore/Domain/BaseEntity.cs
@@ -1,9 +1,8 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Smartstore.Data;
+using SqlSugar;
 
 namespace Smartstore.Domain
 {
@@ -15,7 +14,7 @@ namespace Smartstore.Domain
         private ILazyLoader _lazyLoader;
         private Dictionary<string, object> _hookState;
 
-        [IgnoreDataMember, NotMapped]
+        [IgnoreDataMember, SugarColumn(IsIgnore = true)]
         protected internal virtual ILazyLoader LazyLoader
         {
             get => _lazyLoader ?? NullLazyLoader.Instance;
@@ -25,7 +24,7 @@ namespace Smartstore.Domain
         /// <summary>
         /// Gets or sets the entity identifier
         /// </summary>
-        [Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        [SugarColumn(IsPrimaryKey = true, IsIdentity = true)]
         public long Id { get; set; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary
- migrate base entity identifier to SqlSugar attributes
- replace NotMapped and ForeignKey annotations with SqlSugar attributes
- adjust navigation properties for SqlSugar conventions

## Testing
- `dotnet test -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7cdf8d04832087bcda7d49d43e31