### PR TITLE
refactor: use SqlSugar for test db

### DIFF
--- a/test/Smartstore.Core.Tests/Catalog/Rules/Filters/FilterTestsBase.cs
+++ b/test/Smartstore.Core.Tests/Catalog/Rules/Filters/FilterTestsBase.cs
@@ -18,14 +18,14 @@ namespace Smartstore.Core.Tests.Rules.Filters
     {
         private List<Customer> _customers;
 
-        private CustomerRole _role1 = new() { Id = 1, Active = true, TaxExempt = false, TaxDisplayType = 1 };
-        private CustomerRole _role2 = new() { Id = 2, Active = true, TaxExempt = true, TaxDisplayType = 1 };
-        private CustomerRole _role3 = new() { Id = 3, Active = false, TaxExempt = false, TaxDisplayType = 1 };
-        private CustomerRole _role4 = new() { Id = 4, Active = true, TaxExempt = false, TaxDisplayType = 2 };
+        private CustomerRole _role1 = new() { Id = 1L, Active = true, TaxExempt = false, TaxDisplayType = 1 };
+        private CustomerRole _role2 = new() { Id = 2L, Active = true, TaxExempt = true, TaxDisplayType = 1 };
+        private CustomerRole _role3 = new() { Id = 3L, Active = false, TaxExempt = false, TaxDisplayType = 1 };
+        private CustomerRole _role4 = new() { Id = 4L, Active = true, TaxExempt = false, TaxDisplayType = 2 };
 
-        private Store _store1 = new() { Id = 1 };
-        private Store _store2 = new() { Id = 2 };
-        private Store _store3 = new() { Id = 3 };
+        private Store _store1 = new() { Id = 1L };
+        private Store _store2 = new() { Id = 2L };
+        private Store _store3 = new() { Id = 3L };
 
         private string _pay1 = "Payment1";
         private string _pay2 = "Payment2";

--- a/test/Smartstore.Test.Common/Smartstore.Test.Common.csproj
+++ b/test/Smartstore.Test.Common/Smartstore.Test.Common.csproj
@@ -8,7 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extras.Moq" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
+    <PackageReference Include="SqlSugarCore" Version="5.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.3.2" />

--- a/test/Smartstore.Test.Common/TestDataProvider.cs
+++ b/test/Smartstore.Test.Common/TestDataProvider.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Smartstore.Data;
 using Smartstore.Data.Providers;
+using SqlSugar;
 
 namespace Smartstore.Test.Common
 {
@@ -16,7 +17,7 @@ namespace Smartstore.Test.Common
         }
 
         public override DbSystemType ProviderType
-            => DbSystemType.Unknown;
+            => DbSystemType.Sqlite;
 
         public override bool MARSEnabled
             => true;

--- a/test/Smartstore.Test.Common/TestDbFactory.cs
+++ b/test/Smartstore.Test.Common/TestDbFactory.cs
@@ -1,26 +1,53 @@
 ﻿using System;
 using System.Data.Common;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Smartstore.Data;
 using Smartstore.Data.Providers;
+using SqlSugar;
 
 namespace Smartstore.Test.Common
 {
     public class TestDbFactory : DbFactory
     {
+        private readonly SqliteConnection _connection;
+
+        public TestDbFactory()
+        {
+            // Single shared in‑memory connection so that EF and SqlSugar can operate
+            // on the same database during a test run.
+            _connection = new SqliteConnection("DataSource=:memory:");
+            _connection.Open();
+
+            SugarClient = new SqlSugarClient(new ConnectionConfig
+            {
+                ConnectionString = _connection.ConnectionString,
+                DbType = DbType.Sqlite,
+                IsAutoCloseConnection = true,
+                InitKeyType = InitKeyType.Attribute
+            });
+
+            // Create the database schema once for all tests
+            SugarClient.DbMaintenance.CreateDatabase();
+        }
+
+        public ISqlSugarClient SugarClient { get; }
+
         public override DbSystemType DbSystem { get; } = DbSystemType.Unknown;
 
         public override DbConnectionStringBuilder CreateConnectionStringBuilder(string connectionString)
-            => throw new NotImplementedException();
+            => new SqliteConnectionStringBuilder(connectionString);
 
         public override DbConnectionStringBuilder CreateConnectionStringBuilder(
             string server,
             string database,
             string userName,
             string password)
-            => throw new NotImplementedException();
+            => new SqliteConnectionStringBuilder
+            {
+                DataSource = database
+            };
 
         public override DataProvider CreateDataProvider(DatabaseFacade database)
             => new TestDataProvider(database);
@@ -28,17 +55,14 @@ namespace Smartstore.Test.Common
         public override TContext CreateDbContext<TContext>(string connectionString, int? commandTimeout = null)
         {
             var optionsBuilder = new DbContextOptionsBuilder<TContext>()
-                .UseInMemoryDatabase("Test")
-                .ConfigureWarnings(b => b.Ignore(InMemoryEventId.TransactionIgnoredWarning));
+                .UseSqlite(_connection);
 
-            return (TContext)Activator.CreateInstance(typeof(TContext), new object[] { optionsBuilder.Options });
+            return (TContext)Activator.CreateInstance(typeof(TContext), optionsBuilder.Options);
         }
 
         public override DbContextOptionsBuilder ConfigureDbContext(DbContextOptionsBuilder builder, string connectionString)
         {
-            return builder
-                .UseInMemoryDatabase("Test")
-                .ConfigureWarnings(b => b.Ignore(InMemoryEventId.TransactionIgnoredWarning));
+            return builder.UseSqlite(_connection);
         }
     }
 }


### PR DESCRIPTION
## Summary
- swap EF in-memory setup for a shared SQLite database backed by SqlSugar
- mark data provider as SQLite implementation and expose SqlSugar client
- update tests to use long identifiers

## Testing
- `dotnet test test/Smartstore.Test.Common/Smartstore.Test.Common.csproj -c Release` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9d9ebdbc8320863b9e5843fa79f6